### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,13 @@ jobs:
           if gh secret list | grep -q "GIST_ID"
           then
               echo "GIST_ID found"
-              echo ::set-output name=GIST::${{ secrets.GIST_ID }}
+              echo GIST=${{ secrets.GIST_ID }} >> "$GITHUB_OUTPUT"
               curl https://gist.githubusercontent.com/${{ github.actor }}/${{ secrets.GIST_ID }}/raw/clone.json > clone_before.json
               if cat clone_before.json | grep '404: Not Found'; then
                 echo "GIST_ID not valid anymore. Creating another gist..."
                 gist_id=$(gh gist create clone.json | awk -F / '{print $NF}')
                 echo $gist_id | gh secret set GIST_ID
-                echo ::set-output name=GIST::$gist_id
+                echo GIST=$gist_id >> "$GITHUB_OUTPUT"
                 cp clone.json clone_before.json
                 git rm --ignore-unmatch  CLONE.md
               fi
@@ -42,7 +42,7 @@ jobs:
               echo "GIST_ID not found. Creating a gist..."
               gist_id=$(gh gist create clone.json | awk -F / '{print $NF}')
               echo $gist_id | gh secret set GIST_ID
-              echo ::set-output name=GIST::$gist_id
+              echo GIST=$gist_id >> "$GITHUB_OUTPUT"
               cp clone.json clone_before.json
           fi
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What is this solution indented for?
 
-AWS-CIMA (Case Insights for Multi-Accounts) presents a visualization dashboard that simplifies the task of overseeing and tracking cases across multiple accounts and multiple aws organization. This dashboard streamlines the process of monitoring cases, so customers can conveniently manage and track the status and progress of all cases without logging in to each individual AWS account.
+AWS-CIMA (Consolidated Insights for Multi-Accounts) presents a visualization dashboard that simplifies the task of overseeing and tracking cases across multiple accounts and multiple aws organization. This dashboard streamlines the process of monitoring cases, so customers can conveniently manage and track the status and progress of all cases without logging in to each individual AWS account.
 
 **Key Features:**
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter